### PR TITLE
update antlr4 dependency to fix ambiguous import issue #21

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/bilibili/gengine
 go 1.13
 
 require (
-	github.com/antlr/antlr4 v0.0.0-20210105192202-5c2b686f95e1
+	github.com/antlr/antlr4/runtime/Go/antlr v0.0.0-20210504190105-c37cfeb7559d
 	github.com/golang-collections/collections v0.0.0-20130729185459-604e922904d3
 	github.com/google/martian v2.1.0+incompatible
 	github.com/stretchr/testify v1.7.0


### PR DESCRIPTION
相关issue https://github.com/bilibili/gengine/issues/21
为了尽量减少antlr4版本差异导致的兼容性问题，我这里选择了跟原来版本最接近的，第一个有go.mod文件的版本

可能的风险：由于目前gengine main分支执行 `go test  ./...` 单元测试也是跑不过的，所以难以验证此修改后会不会带来新的问题